### PR TITLE
Fix notification object docs issue 8 and 5

### DIFF
--- a/SyphonServerDirectory.h
+++ b/SyphonServerDirectory.h
@@ -41,21 +41,21 @@ extern NSString * const SyphonServerDescriptionUUIDKey;
 
 /*!
  @relates SyphonServerDirectory
- The object for this key is a NSString which is the human-readable non-unique name for the SyphonServer. If this string exists and is non-empty, you should use it in interface elements to identify the server, usually in combination with the name of the server's application (see SyphonServerDescriptionAppNameKey).
+ The object for this key is a NSString which is the human-readable non-unique name for the SyphonServer. If this string exists and is non-empty, you should use it in interface elements to identify the server, usually in combination with the name of the server's application (see SyphonServerDescriptionAppNameKey). This key is not guaranteed to exist in the dictionary. May be nil.
 */
 
 extern NSString * const SyphonServerDescriptionNameKey;
 
 /*!
  @relates SyphonServerDirectory
- The object for this key is a NSString with the localized name of the application in which the SyphonServer is running. Use this in combination with the server's name (if present) to identify the server in interface elements.
+ The object for this key is a NSString with the localized name of the application in which the SyphonServer is running. Use this in combination with the server's name (if present) to identify the server in interface elements.  This key is not guaranteed to exist in the dictionary. May be nil.
 */
 
 extern NSString * const SyphonServerDescriptionAppNameKey;
 
 /*!
  @relates SyphonServerDirectory
- The object for this key is a NSImage representation of the icon of the application in which the SyphonServer is running.
+ The object for this key is a NSImage representation of the icon of the application in which the SyphonServer is running. This key is not guaranteed to exist in the dictionary. May be nil.
 */
 
 extern NSString * const SyphonServerDescriptionIconKey;

--- a/SyphonServerDirectory.h
+++ b/SyphonServerDirectory.h
@@ -34,7 +34,7 @@
 
 /*!
  @relates SyphonServerDirectory
- The object for this key is a NSString which uniquely identifies a SyphonServer instance. If two dictionaries contain the same string for this key, they represent the same server. This is provided solely to allow you to programmatically determine the identity of a server, and should never be displayed to users in interface elements. This key is not guaranteed to exist in the dictionary. May be nil.
+ The object for this key is a NSString which uniquely identifies a SyphonServer instance. If two dictionaries contain the same string for this key, they represent the same server. This is provided solely to allow you to programmatically determine the identity of a server, and should never be displayed to users in interface elements. This key is not guaranteed to exist in the dictionary.
 
 */
 
@@ -42,21 +42,21 @@ extern NSString * const SyphonServerDescriptionUUIDKey;
 
 /*!
  @relates SyphonServerDirectory
- The object for this key is a NSString which is the human-readable non-unique name for the SyphonServer. If this string exists and is non-empty, you should use it in interface elements to identify the server, usually in combination with the name of the server's application (see SyphonServerDescriptionAppNameKey). This key is not guaranteed to exist in the dictionary. May be nil.
+ The object for this key is a NSString which is the human-readable non-unique name for the SyphonServer. If this string exists and is non-empty, you should use it in interface elements to identify the server, usually in combination with the name of the server's application (see SyphonServerDescriptionAppNameKey). This key is not guaranteed to exist in the dictionary.
 */
 
 extern NSString * const SyphonServerDescriptionNameKey;
 
 /*!
  @relates SyphonServerDirectory
- The object for this key is a NSString with the localized name of the application in which the SyphonServer is running. Use this in combination with the server's name (if present) to identify the server in interface elements.  This key is not guaranteed to exist in the dictionary. May be nil.
+ The object for this key is a NSString with the localized name of the application in which the SyphonServer is running. Use this in combination with the server's name (if present) to identify the server in interface elements.  This key is not guaranteed to exist in the dictionary.
 */
 
 extern NSString * const SyphonServerDescriptionAppNameKey;
 
 /*!
  @relates SyphonServerDirectory
- The object for this key is a NSImage representation of the icon of the application in which the SyphonServer is running. This key is not guaranteed to exist in the dictionary. May be nil.
+ The object for this key is a NSImage representation of the icon of the application in which the SyphonServer is running. This key is not guaranteed to exist in the dictionary.
 */
 
 extern NSString * const SyphonServerDescriptionIconKey;
@@ -68,21 +68,21 @@ extern NSString * const SyphonServerDescriptionIconKey;
 
 /*!
  @relates SyphonServerDirectory
- A new SyphonServer is available on the system. The notification user info object is a NSDictionary describing the server which may contain SyphonServerDescription keys.
+ A new SyphonServer is available on the system. The notification object is the shared SyphonServerDirectory instance. The user info dictionary describes the server and may contain SyphonServerDescription keys.
 */
 
 extern NSString * const SyphonServerAnnounceNotification;
 
 /*!
  @relates SyphonServerDirectory
- An existing SyphonServer instance has changed its description. The notification user info object is a NSDictionary describing the server which may contain SyphonServerDescription keys.
+ An existing SyphonServer instance has changed its description. The notification object is the shared SyphonServerDirectory instance. The user info dictionary describes the server and may contain SyphonServerDescription keys.
 */
 
 extern NSString * const SyphonServerUpdateNotification;
 
 /*!
  @relates SyphonServerDirectory
- A SyphonServer instance will no longer be available. The notification user info object is a NSDictionary describing the retiring server which may contain SyphonServerDescription keys.
+ A SyphonServer instance will no longer be available.  The notification object is the shared SyphonServerDirectory instance. The user info dictionary describes the retiring server and may contain SyphonServerDescription keys.
 */
 
 extern NSString * const SyphonServerRetireNotification;

--- a/SyphonServerDirectory.h
+++ b/SyphonServerDirectory.h
@@ -34,7 +34,8 @@
 
 /*!
  @relates SyphonServerDirectory
- The object for this key is a NSString which uniquely identifies a SyphonServer instance. If two dictionaries contain the same string for this key, they represent the same server. This is provided solely to allow you to programmatically determine the identity of a server, and should never be displayed to users in interface elements.
+ The object for this key is a NSString which uniquely identifies a SyphonServer instance. If two dictionaries contain the same string for this key, they represent the same server. This is provided solely to allow you to programmatically determine the identity of a server, and should never be displayed to users in interface elements. This key is not guaranteed to exist in the dictionary. May be nil.
+
 */
 
 extern NSString * const SyphonServerDescriptionUUIDKey;
@@ -67,21 +68,21 @@ extern NSString * const SyphonServerDescriptionIconKey;
 
 /*!
  @relates SyphonServerDirectory
- A new SyphonServer is available on the system. The notification object is a NSDictionary describing the server.
+ A new SyphonServer is available on the system. The notification user info object is a NSDictionary describing the server which may contain SyphonServerDescription keys.
 */
 
 extern NSString * const SyphonServerAnnounceNotification;
 
 /*!
  @relates SyphonServerDirectory
- An existing SyphonServer instance has changed its description. The notification object is a NSDictionary describing the server.
+ An existing SyphonServer instance has changed its description. The notification user info object is a NSDictionary describing the server which may contain SyphonServerDescription keys.
 */
 
 extern NSString * const SyphonServerUpdateNotification;
 
 /*!
  @relates SyphonServerDirectory
- A SyphonServer instance will no longer be available. The notification object is a NSDictionary describing the retiring server.
+ A SyphonServer instance will no longer be available. The notification user info object is a NSDictionary describing the retiring server which may contain SyphonServerDescription keys.
 */
 
 extern NSString * const SyphonServerRetireNotification;

--- a/SyphonServerDirectory.m
+++ b/SyphonServerDirectory.m
@@ -247,7 +247,7 @@ NSString * const SyphonServerRetireNotification = @"SyphonServerRetireNotificati
 			pthread_mutex_unlock(&_generalLock);
 			pthread_mutex_unlock(&_mutateLock);
 			for (NSDictionary *description in retired) {
-				[[NSNotificationCenter defaultCenter] postNotificationName:SyphonServerRetireNotification object:description userInfo:nil];
+				[[NSNotificationCenter defaultCenter] postNotificationName:SyphonServerRetireNotification object:self userInfo:description];
 			}
 		});		
 	}
@@ -282,7 +282,7 @@ NSString * const SyphonServerRetireNotification = @"SyphonServerRetireNotificati
 		pthread_mutex_unlock(&_generalLock);
 		[self didChange:NSKeyValueChangeInsertion valuesAtIndexes:indexSet forKey:@"servers"];
 		
-		[[NSNotificationCenter defaultCenter] postNotificationName:SyphonServerAnnounceNotification object:serverInfo userInfo:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationName:SyphonServerAnnounceNotification object:self userInfo:serverInfo];
 	}
 	// unlock mutate lock
 	pthread_mutex_unlock(&_mutateLock);
@@ -312,7 +312,7 @@ NSString * const SyphonServerRetireNotification = @"SyphonServerRetireNotificati
 		pthread_mutex_unlock(&_generalLock);
 		[self didChange:NSKeyValueChangeRemoval valuesAtIndexes:indexSet forKey:@"servers"];
 		
-		[[NSNotificationCenter defaultCenter] postNotificationName:SyphonServerRetireNotification object:serverInfo userInfo:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationName:SyphonServerRetireNotification object:self userInfo:serverInfo];
 	}
 	// unlock mutate lock
 	pthread_mutex_unlock(&_mutateLock);
@@ -342,7 +342,7 @@ NSString * const SyphonServerRetireNotification = @"SyphonServerRetireNotificati
 		pthread_mutex_unlock(&_generalLock);
 		[self didChange:NSKeyValueChangeReplacement valuesAtIndexes:indexSet forKey:@"servers"];
 				
-		[[NSNotificationCenter defaultCenter] postNotificationName:SyphonServerUpdateNotification object:serverInfo userInfo:nil];
+		[[NSNotificationCenter defaultCenter] postNotificationName:SyphonServerUpdateNotification object:self userInfo:serverInfo];
 	}
 	pthread_mutex_unlock(&_mutateLock);
 }


### PR DESCRIPTION
Hey @bangnoise 

Some quick work in a PR

* Doc changes to clarify / fix a remaining issue (see #5 ). Question : it appears that the server UUID is treated as optional in the code (i.e., SyphonServerDictionary attempts to handle NSNotFound or the key not existing cases). Is it in fact optional? I did not mark it as so. My understanding is all must servers have a UUID. 

* Fix our outstanding notification posting nuance where object does not refer to the SyphonServerDirectory posting the notification ( #8) . Thats fixed and some quick testing indicates it works. Let me know how royally I fucked that one up, haha. :'(

<3