### PR TITLE
Clean : move definition and imports in implementation files

### DIFF
--- a/SyphonClientConnectionManager.h
+++ b/SyphonClientConnectionManager.h
@@ -31,7 +31,6 @@
 #import <Cocoa/Cocoa.h>
 #import <IOSurface/IOSurface.h>
 #import <libkern/OSAtomic.h>
-#import "SyphonMessaging.h"
 #import "SyphonImage.h"
 
 /* This object handles messaging to and from the server.
@@ -60,22 +59,6 @@
 #define SYPHON_CLIENT_CONNECTION_MANAGER_UNIQUE_CLASS_NAME SYPHON_UNIQUE_CLASS_NAME(SyphonClientConnectionManager)
 
 @interface SYPHON_CLIENT_CONNECTION_MANAGER_UNIQUE_CLASS_NAME : NSObject
-{
-@private
-	NSString *_myUUID;
-	IOSurfaceID _surfaceID;
-	IOSurfaceRef _surface;
-	uint32_t _lastSeed;
-	NSUInteger _frameID;
-	NSString *_serverUUID;
-	BOOL _serverActive;
-	SyphonMessageReceiver *_connection;
-	int32_t _handlerCount;
-    NSHashTable *_infoClients;
-	NSHashTable *_frameClients;
-	dispatch_queue_t _frameQueue;
-	OSSpinLock _lock;
-}
 - (id)initWithServerDescription:(NSDictionary *)description;
 @property (readonly) BOOL isValid;
 - (void)addInfoClient:(id <SyphonInfoReceiving>)client isFrameClient:(BOOL)frameClient;     // Must be

--- a/SyphonClientConnectionManager.m
+++ b/SyphonClientConnectionManager.m
@@ -33,6 +33,7 @@
 #import "SyphonCGL.h"
 #import "SyphonIOSurfaceImageCore.h"
 #import "SyphonIOSurfaceImageLegacy.h"
+#import "SyphonMessaging.h"
 
 #pragma mark Shared Instances
 
@@ -80,6 +81,22 @@ static void SyphonClientPrivateRemoveInstance(id instance, NSString *uuid)
 - (void)invalidateFramesHavingLock;
 @end
 @implementation SyphonClientConnectionManager
+{
+@private
+    NSString *_myUUID;
+    IOSurfaceID _surfaceID;
+    IOSurfaceRef _surface;
+    uint32_t _lastSeed;
+    NSUInteger _frameID;
+    NSString *_serverUUID;
+    BOOL _serverActive;
+    SyphonMessageReceiver *_connection;
+    int32_t _handlerCount;
+    NSHashTable *_infoClients;
+    NSHashTable *_frameClients;
+    dispatch_queue_t _frameQueue;
+    OSSpinLock _lock;
+}
 
 - (id)initWithServerDescription:(NSDictionary *)description
 {

--- a/SyphonServerConnectionManager.h
+++ b/SyphonServerConnectionManager.h
@@ -29,8 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #import <Cocoa/Cocoa.h>
-#import "SyphonMessaging.h"
-#import "SyphonPrivate.h"
 
 /*
  This class is not KVO compliant for serverDescription, as changes to name won't raise a notification for serverDescription
@@ -39,17 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define SYPHON_SERVER_CONNECTION_MANAGER_UNIQUE_CLASS_NAME SYPHON_UNIQUE_CLASS_NAME(SyphonServerConnectionManager)
 
-@interface SYPHON_SERVER_CONNECTION_MANAGER_UNIQUE_CLASS_NAME : NSObject {
-@private
-	SyphonMessageReceiver *_connection;
-	NSMutableDictionary *_infoClients;
-	NSMutableDictionary *_frameClients;
-	BOOL _alive;
-	NSString *_uuid;
-	IOSurfaceID _surfaceID;
-	SyphonSafeBool _hasClients;
-	dispatch_queue_t _queue;
-}
+@interface SYPHON_SERVER_CONNECTION_MANAGER_UNIQUE_CLASS_NAME : NSObject
 - (id)initWithUUID:(NSString *)uuid options:(NSDictionary *)options;
 @property (readonly) NSDictionary *surfaceDescription;
 /*

--- a/SyphonServerConnectionManager.m
+++ b/SyphonServerConnectionManager.m
@@ -29,6 +29,7 @@
 
 #import "SyphonServerConnectionManager.h"
 #import "SyphonPrivate.h"
+#import "SyphonMessaging.h"
 
 @interface SyphonServerConnectionManager (Private)
 - (void)addInfoClient:(NSString *)clientUUID;
@@ -38,7 +39,17 @@
 - (void)handleDeadConnection;
 @end
 
-@implementation SyphonServerConnectionManager
+@implementation SyphonServerConnectionManager {
+@private
+    SyphonMessageReceiver *_connection;
+    NSMutableDictionary *_infoClients;
+    NSMutableDictionary *_frameClients;
+    BOOL _alive;
+    NSString *_uuid;
+    IOSurfaceID _surfaceID;
+    SyphonSafeBool _hasClients;
+    dispatch_queue_t _queue;
+}
 
 + (BOOL)automaticallyNotifiesObserversForKey:(NSString *)theKey
 {


### PR DESCRIPTION
Hi,
I moved the implementation variables of the ConnectionManager's classes to their .m file. It permits to remove useless dependencies (SyphonMessaging and SyphonPrivate) of the header file.

Maxime