### PR TITLE
Support Apple Silicon

### DIFF
--- a/Syphon.xcodeproj/project.pbxproj
+++ b/Syphon.xcodeproj/project.pbxproj
@@ -783,7 +783,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
-				VALID_ARCHS = "i386 x86_64";
+				VALID_ARCHS = "i386 x86_64 arm64";
 			};
 			name = Debug;
 		};
@@ -823,7 +823,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
-				VALID_ARCHS = "i386 x86_64";
+				VALID_ARCHS = "i386 x86_64 arm64";
 			};
 			name = Release;
 		};
@@ -870,7 +870,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
-				VALID_ARCHS = "i386 x86_64";
+				VALID_ARCHS = "i386 x86_64 arm64";
 			};
 			name = "Debug Messaging Only";
 		};


### PR DESCRIPTION
This change allows Xcode to compile Syphon.framework as a universal binary for x86_64 and arm64.

In the screenshot you can see Simple Server running natively on Apple Silicon, while Syphon Recorder runs under Rosetta.

<img width="974" alt="Screenshot 2020-11-09 at 10 29 31" src="https://user-images.githubusercontent.com/6740187/98563351-5bcf5b00-22ab-11eb-8f40-075e765f65b4.png">
