### PR TITLE
Fixed random crash when creating client

### DIFF
--- a/SyphonClientBase.m
+++ b/SyphonClientBase.m
@@ -70,10 +70,10 @@ static void *SyphonClientServersContext = &SyphonClientServersContext;
     {
         _lock = OS_SPINLOCK_INIT;
 
-        _connectionManager = [[SyphonClientConnectionManager alloc] initWithServerDescription:description];
-
         _handler = [handler copy]; // copy don't retain
         _serverDescription = [description retain];
+
+        _connectionManager = [[SyphonClientConnectionManager alloc] initWithServerDescription:description];
 
         [[SyphonServerDirectory sharedDirectory] addObserver:self
                                                   forKeyPath:@"servers"


### PR DESCRIPTION
When creating / deleting the syphon client multiple times per second for 5 minutes while server is pushing frames at 60 FPS, I generally get a crash because we get a new frame from server before "SyphonClientBase::_handler" variable is initialized. 
This patch solved the issue