### PR TITLE
[WIP] Direct surface publishing using SyphonServerBase

### DIFF
--- a/Syphon.h
+++ b/Syphon.h
@@ -33,6 +33,7 @@
 #import <Syphon/SyphonOpenGLServer.h>
 #import <Syphon/SyphonOpenGLClient.h>
 #import <Syphon/SyphonOpenGLImage.h>
+#import <Syphon/SyphonServerBase.h>
 
 /*
  Deprecated headers

--- a/SyphonServerBase.h
+++ b/SyphonServerBase.h
@@ -28,6 +28,7 @@
 */
 
 #import <Foundation/Foundation.h>
+#import <IOSurface/IOSurface.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -63,6 +64,16 @@ extern NSString * const SyphonServerOptionIsPrivate;
  YES if clients are currently attached, NO otherwise. If you generate frames frequently (for instance on a display-link timer), you may choose to test this and only call publishFrameTexture:textureTarget:imageRegion:textureDimensions:flipped: when clients are attached.
  */
 @property (readonly) BOOL hasClients;
+
+
+/*!
+ Direclty publish an IOSurface you own. Note your surface MUST have kIOSurfaceIsGlobal property set to true, otherwise you will fail to publish and silently die
+ This API  circumvents normal Syphon Server operations, and does not opt in to IOSurface re-use, which makes this sub optimal in most, but not all situations.
+ 
+ This function will retain the surface until the next publishSurface: call, at which point the surface will be released, and the new incoming surface will be retained. 
+ */
+- (void)publishSurface:(IOSurfaceRef)surface;
+
 
 /*!
  Stops the server instance. Use of this method is optional and releasing all references to the server has the same effect.

--- a/SyphonServerBase.m
+++ b/SyphonServerBase.m
@@ -266,6 +266,25 @@ static void finalizer(void)
     return _surface;
 }
 
+- (void)publishSurface:(IOSurfaceRef)surface
+{
+    if (_surface)
+    {
+        CFRelease(_surface);
+    }
+    
+    _surface = surface;
+    
+    if (_surface)
+    {
+        // Return retained (caller releases)
+        CFRetain(_surface);
+        _pushPending = true;
+    }
+    
+    [self publish];
+}
+
 - (void)publish
 {
     if (_pushPending)
@@ -276,6 +295,7 @@ static void finalizer(void)
     }
     [(SyphonServerConnectionManager *)_connectionManager publishNewFrame];
 }
+
 #pragma mark Notification Handling for Server Presence
 /*
  Broadcast and discovery is done via NSDistributedNotificationCenter. Servers notify announce, change (currently only affects name) and retirement.


### PR DESCRIPTION
This is a WIP / Proof of concept PR

This implements direct publishing of an IOSurface through SyphonServerBase class, 

`- (void)publishSurface:(IOSurfaceRef)surface;`

You must meet the following requirements EXTERNAL to this new api

* Your surface must be global
* it must be in a supported format that syphon clients expect.

This does not currently enforce any of those safety guards, but it could be added. 

Internally this abuses publish, and every time the `publishSurface:` method is called we re-broadcast the new incoming IOSurfaces ID to other clients.

This is clearly suboptimal, but .. its useful in some situations:

1. I have an IOSurface pool that I dont directly control, but can mark properties of (ie global)
2. I dont have, need, or want Metal or OpenGL contexts at all, as im just a stupid video app working with CVPixelBuffers directly.
3. Due to the above, I dont have want to manage GPU devices, command buffers and other shite, I already have a surface read to go.

This also addresses issue #67 