### PR TITLE
Explicitly set pixel format type to 32BGRA

### DIFF
--- a/SyphonServerBase.m
+++ b/SyphonServerBase.m
@@ -252,6 +252,7 @@ static void finalizer(void)
         NSDictionary<NSString *, id> *surfaceAttributes = @{(NSString*)kIOSurfaceIsGlobal: @(YES),
                                                             (NSString*)kIOSurfaceWidth: @(width),
                                                             (NSString*)kIOSurfaceHeight: @(height),
+                                                            (NSString*)kIOSurfacePixelFormat: @(kCVPixelFormatType_32BGRA),
                                                             (NSString*)kIOSurfaceBytesPerElement: @(4U)};
 
         _surface =  IOSurfaceCreate((CFDictionaryRef) surfaceAttributes);


### PR DESCRIPTION
When receiving IOSurfaces from Syphon, calling `IOSurfaceGetPixelFormat` on them returns `0`. This is not ideal. In fact, per the [Apple documentation](https://developer.apple.com/documentation/iosurface/iosurfacegetpixelformat(_:)?language=objc#return-value), 0 is returned when the IOSurfaces are invalid.

This was discovered in OBS Studio when an unknown bug that treated `0` as `...32BGRA` instead of invalid was accidentally fixed in a code refactor. The IOSurfaces from Syphon however were all 32BGRA, so treating them as such happened to work, until this fix that actually treats them as invalid, leading to Syphon sources no longer working. This will be un-fixed in OBS to restore previous behavior, but it would still be nice to have the IOSurfaces return their proper pixel format (so that maybe in the future, this un-fix won't be necessary anymore).

I tested this by building the simple server against this patched version of the framework and receiving it in [OBS Studio 31.0.1](https://github.com/obsproject/obs-studio/releases/tag/32.0.1) (which rejects `0`) and confirmed that it receives the images correctly (note that 31.0.2 will likely have the patch that will make `0` "work" again, so using specifically 32.0.1 (or an earlier 32.0 release or beta) to test is important).